### PR TITLE
Correct a transcription error

### DIFF
--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -33,8 +33,7 @@
 			<p>“Who did you hear it from?”</p>
 			<p>“Aunt Dahlia.”</p>
 			<p>“I suppose she cursed me properly?”</p>
-			<p>“Oh, no.”</p>
-			<p>“Beyond referring to you in one passage as ‘this blasted Glossop,’ she was, I thought, singularly temperate in her language for a woman who at one time hunted regularly with the Quorn. All the same, I could see, if you don’t mind me saying so, old man, that she felt you might have behaved with a little more tact.”</p>
+			<p>“Oh, no. Beyond referring to you in one passage as ‘this blasted Glossop,’ she was, I thought, singularly temperate in her language for a woman who at one time hunted regularly with the Quorn. All the same, I could see, if you don’t mind me saying so, old man, that she felt you might have behaved with a little more tact.”</p>
 			<p>“Tact!”</p>
 			<p>“And I must admit I rather agreed with her. Was it nice, Tuppy, was it quite kind to take the bloom off Angela’s shark like that? You must remember that Angela’s shark is very dear to her. Could you not see what a sock on the jaw it would be for the poor child to hear it described by the man to whom she had given her heart as a flatfish?”</p>
 			<p>I saw that he was struggling with some powerful emotion.</p>


### PR DESCRIPTION
This commit removes an incorrect paragraph break (see [page scan](https://archive.org/details/RightHoJeeves/page/n55)).