### PR TITLE
dashed fed with Jeeves => dashed fed-up with Jeeves

### DIFF
--- a/src/epub/text/chapter-2.xhtml
+++ b/src/epub/text/chapter-2.xhtml
@@ -59,7 +59,7 @@
 			<p>“Thanks, old man. And Jeeves, of course, which is the thing that really matters.”</p>
 			<p>I don’t mind admitting that I winced. He meant no harm, I suppose, but I’m bound to say that this tactless speech nettled me not a little. People are always nettling me like that. Giving me to understand, I mean to say, that in their opinion Bertram Wooster is a mere cipher and that the only member of the household with brains and resources is Jeeves.</p>
 			<p>It jars on me.</p>
-			<p>And tonight it jarred on me more than usual, because I was feeling pretty dashed fed with Jeeves. Over that matter of the mess jacket, I mean. True, I had forced him to climb down, quelling him, as described, with the quiet strength of my personality, but I was still a trifle shirty at his having brought the thing up at all. It seemed to me that what Jeeves wanted was the iron hand.</p>
+			<p>And tonight it jarred on me more than usual, because I was feeling pretty dashed fed-up with Jeeves. Over that matter of the mess jacket, I mean. True, I had forced him to climb down, quelling him, as described, with the quiet strength of my personality, but I was still a trifle shirty at his having brought the thing up at all. It seemed to me that what Jeeves wanted was the iron hand.</p>
 			<p>“And what is he doing about it?” I inquired stiffly.</p>
 			<p>“He’s been giving the position of affairs a lot of thought.”</p>
 			<p>“He has, has he?”</p>


### PR DESCRIPTION
Although the the [officially linked page scans at Internet Archive](https://archive.org/details/RightHoJeeves/page/n21/mode/2up) first published in 1922 has this as "I was feeling pretty dashed fed with Jeeves," [this later edition](https://archive.org/details/righthojeeves0000wode_v6z7/page/20/mode/2up) (page 20) first published in 1934 has it as "I was feeling pretty dashed fed-up with Jeeves."

[Merriam Webster](https://www.merriam-webster.com/dictionary/fed%20up) states the expression "fed up" was first used in 1900. While it could be argued that Wodehouse meant to use "fed" meaning just "sated," rather than "fed-up" meaning "sated beyond endurance," I think the 1934 edition is an improvement.