### PR TITLE
Take artist name out of i tags

### DIFF
--- a/src/epub/text/chapter-18.xhtml
+++ b/src/epub/text/chapter-18.xhtml
@@ -117,7 +117,7 @@
 			<p>“Have you locked the door, Jeeves?”</p>
 			<p>“Yes, sir.”</p>
 			<p>“Because you can never tell that that ghastly Glossop may not take it into his head to come⁠—”</p>
-			<p>The word “back” froze on his lips. He hadn’t got any further than a <i epub:type="z3998:grapheme">b</i>-ish sound, when the handle of the door began to twist and rattle. He sprang from the bed, and for an instant stood looking exactly like a picture my Aunt Agatha has in her dining-room⁠—<i epub:type="se:name.visual-art.painting">The Stag at Bay⁠—Landseer</i>. Then he made a dive for the cupboard and was inside it before one really got on to it that he had started leaping. I have seen fellows late for the 9:15 move less nippily.</p>
+			<p>The word “back” froze on his lips. He hadn’t got any further than a <i epub:type="z3998:grapheme">b</i>-ish sound, when the handle of the door began to twist and rattle. He sprang from the bed, and for an instant stood looking exactly like a picture my Aunt Agatha has in her dining-room⁠—<i epub:type="se:name.visual-art.painting">The Stag at Bay⁠</i>—Landseer. Then he made a dive for the cupboard and was inside it before one really got on to it that he had started leaping. I have seen fellows late for the 9:15 move less nippily.</p>
 			<p>I shot a glance at Jeeves. He allowed his right eyebrow to flicker slightly, which is as near as he ever gets to a display of the emotions.</p>
 			<p>“Hullo?” I yipped.</p>
 			<p>“Let me in, blast you!” responded Tuppy’s voice from without. “Who locked this door?”</p>


### PR DESCRIPTION
"Landseer" refers to Edwin Landseer, an English painter who presumably painted the work *The Stag at Bay*.  The artist name shouldn't be in italics.

The original scan uses no italics at all.