### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Right Ho, Jeeves</i><br/>
-			was published in 1922 by<br/>
+			was published in 1934 by<br/>
 			<a href="https://en.wikipedia.org/wiki/P._G._Wodehouse"><abbr epub:type="z3998:given-name">P. G.</abbr> Wodehouse</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
**Changed the publication date to 1934.**

**Sources:**
- Internet Archive: 
https://archive.org/details/righthojeeves00pgwo/page/4/mode/2up

https://archive.org/details/righthojeeves0000wode_m1s3/page/n7/mode/2up

https://archive.org/details/righthojeeves0000wode_f0r9/page/n3/mode/2up

**PS:** 
This book's editions in some of the Indian Libraries on the Internet Archive wrongly state the publication date as 1922. There is no other record of this in any other source (Internet Archive (other editions of this book listed above all state that the book was first published in 1934), British Library, Wikipedia (even the serialization dates are '23 December 1933 to 27 January 1934' in Saturday Evening Post and 'April to September 1934' in Grand Magazine).